### PR TITLE
Convert to log window

### DIFF
--- a/UI/src/gui/app/AppController.java
+++ b/UI/src/gui/app/AppController.java
@@ -51,7 +51,7 @@ public class AppController implements HasFileLoadedListeners, BarNotifier, Engin
     @Override
     public void showNotification(String notification){
         anchorNotification.visibleProperty().set(true);
-        notificationBarComponentController.setLblNotificationText(notification);
+        notificationBarComponentController.addNotification(notification);
     }
 
     @Override

--- a/UI/src/gui/execution/control/bar/ControlBarController.java
+++ b/UI/src/gui/execution/control/bar/ControlBarController.java
@@ -24,6 +24,7 @@ public class ControlBarController implements BarNotifier, EngineCommunicator {
     @FXML
     void clearButtonActionListener(ActionEvent event) {
         mainController.clearInputs();
+        getNotificationBar().showNotification("Cleared all inputs from user.");
     }
 
     @FXML

--- a/UI/src/gui/execution/control/bar/ControlBarController.java
+++ b/UI/src/gui/execution/control/bar/ControlBarController.java
@@ -23,17 +23,22 @@ public class ControlBarController implements BarNotifier, EngineCommunicator {
 
     @FXML
     void clearButtonActionListener(ActionEvent event) {
-        mainController.clearInputs();
-        getNotificationBar().showNotification("Cleared all inputs from user.");
+        if(getEngineAgent().isFileLoaded()){
+            mainController.clearInputs();
+            getNotificationBar().showNotification("Cleared all inputs from user.");
+        }
     }
 
     @FXML
     void startButtonActionListener(ActionEvent event) {
-        StartResponse response = getEngineAgent().startSimulation();
+        if(getEngineAgent().isFileLoaded())
+        {
+            StartResponse response = getEngineAgent().startSimulation();
 
-        showNotification(response.getMessage());
-        if(response.isSuccess()){
-            mainController.getMenusTabPane().getSelectionModel().selectLast();
+            showNotification(response.getMessage());
+            if(response.isSuccess()){
+                mainController.getMenusTabPane().getSelectionModel().selectLast();
+            }
         }
     }
 

--- a/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
+++ b/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
@@ -82,10 +82,12 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
             int population = parseTextFieldInput();
 
             if (population != POPULATION_ERROR) {
-                SetResponse response = getEngineAgent().sendPopulationData(new EntityPopulationUserInput(selectedItem.getName(), population));
-                getNotificationBar().showNotification(response.getMessage());
-                if (response.isSuccess()) {
-                    entityPopulations.put(selectedItem, population);
+                if (population != entityPopulations.get(selectedItem)) {
+                    SetResponse response = getEngineAgent().sendPopulationData(new EntityPopulationUserInput(selectedItem.getName(), population));
+                    getNotificationBar().showNotification(response.getMessage());
+                    if (response.isSuccess()) {
+                        entityPopulations.put(selectedItem, population);
+                    }
                 }
             } else {
                 getNotificationBar().showNotification("ERROR: The population value may only be a non negative Integer.");
@@ -118,23 +120,24 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
     /**
      * Sets all entity populations to 0.
      * Both in the UI and in the
+     *
      * @param entities
      */
-    private void initEntityPopulations(List<DTOEntity> entities){
-        for (DTOEntity e:entities
+    private void initEntityPopulations(List<DTOEntity> entities) {
+        for (DTOEntity e : entities
         ) {
-            getEngineAgent().sendPopulationData(new EntityPopulationUserInput(e.getName(),0));
+            getEngineAgent().sendPopulationData(new EntityPopulationUserInput(e.getName(), 0));
             entityPopulations.put(e, 0);
         }
     }
 
-    private void enableComponent(){
+    private void enableComponent() {
         setBTN.disableProperty().set(false);
         entitiesLV.disableProperty().set(false);
         populationTF.disableProperty().set(false);
     }
 
-    private void addItemsToListView(List<DTOEntity> entities){
+    private void addItemsToListView(List<DTOEntity> entities) {
         entitiesLV.getItems().addAll(entities);
         entitiesLV.setCellFactory(new Callback<ListView<DTOEntity>, ListCell<DTOEntity>>() {
             @Override
@@ -158,7 +161,7 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
     /**
      * Sets all entity populations in the engine to 0 and resets accordingly the entity populations map.
      */
-    public void clearInputs(){
+    public void clearInputs() {
         entityPopulations.replaceAll((e, v) -> 0);
         initEntityPopulations(new ArrayList<>(entityPopulations.keySet()));
         resetListView();
@@ -167,7 +170,7 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
     /**
      * Deselects the listview and clears the TF.
      */
-    private void resetListView(){
+    private void resetListView() {
         entitiesLV.getSelectionModel().clearSelection();
         populationTF.setText("");
     }

--- a/UI/src/gui/execution/inputs/env/var/EnvironmentVariableComponentController.java
+++ b/UI/src/gui/execution/inputs/env/var/EnvironmentVariableComponentController.java
@@ -101,7 +101,7 @@ public class EnvironmentVariableComponentController implements FileLoadedEvent, 
         DTOEnvironmentVariable selectedItem = envVarsLV.getSelectionModel().getSelectedItem();
 
         // If there is in fact, a selected item in the list view.
-        if (selectedItem != null) {
+        if (selectedItem != null && !valueTF.getText().equals(environmentVariableMap.get(selectedItem))) {
             SetResponse response;
 
             // If the text field is empty then the environment variable is randomly initialized

--- a/UI/src/gui/notification/NotificationBarComponentController.java
+++ b/UI/src/gui/notification/NotificationBarComponentController.java
@@ -33,6 +33,10 @@ public class NotificationBarComponentController {
 
     private StringBuilder logs;
 
+    Stage logWindow;
+
+    @FXML private LogWindowController logWindowController;
+
     public void setMainController(AppController mainController) {
         this.mainController = mainController;
     }
@@ -43,14 +47,21 @@ public class NotificationBarComponentController {
     }
 
 
-
+    /**
+     * Displays the firs line of the notification on the screen. Adds the date and time this notification is displayed at.
+     * Also adds it to the program logs.
+     */
     public void addNotification(String notification){
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
         addExpandHyperLinkToLabel(notification);
         LocalDateTime ldt = LocalDateTime.now();
         String toDisplay = ldt.format(dtf) + "- " + notification + "\n\n";
-        logs.append(toDisplay);
+        logs.insert(0,toDisplay);
         setLblNotificationText(toDisplay);
+
+        if(logWindow != null && logWindowController != null){
+            logWindowController.changeTextAreaText(logs.toString());
+        }
     }
 
     /**
@@ -90,16 +101,16 @@ public class NotificationBarComponentController {
      */
     private void showLogWindow(String logs) {
         try {
-            Stage stage = new Stage();
-            stage.setTitle("Program logs");
+            logWindow = new Stage();
+            logWindow.setTitle("Program logs");
             FXMLLoader fxmlLoader = new FXMLLoader();
             URL url = getClass().getResource("window/LogWindow.fxml");
             Parent root = fxmlLoader.load(url.openStream());
-            LogWindowController controller = fxmlLoader.getController();
-            controller.initialize(logs);
+            logWindowController = fxmlLoader.getController();
+            logWindowController.initialize(logs);
             Scene scene = new Scene(root);
-            stage.setScene(scene);
-            stage.show();
+            logWindow.setScene(scene);
+            logWindow.show();
         } catch (IOException e) {
             System.out.println(e.getMessage());
         }

--- a/UI/src/gui/notification/NotificationBarComponentController.java
+++ b/UI/src/gui/notification/NotificationBarComponentController.java
@@ -1,7 +1,7 @@
 package gui.notification;
 
 import gui.app.AppController;
-import gui.notification.window.NotificationWindowController;
+import gui.notification.window.LogWindowController;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Insets;
@@ -16,6 +16,8 @@ import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import java.io.IOException;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class NotificationBarComponentController {
 
@@ -29,8 +31,26 @@ public class NotificationBarComponentController {
     @FXML
     private GridPane grdParent;
 
+    private StringBuilder logs;
+
     public void setMainController(AppController mainController) {
         this.mainController = mainController;
+    }
+
+    @FXML
+    public void initialize() {
+        logs = new StringBuilder();
+    }
+
+
+
+    public void addNotification(String notification){
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+        addExpandHyperLinkToLabel(notification);
+        LocalDateTime ldt = LocalDateTime.now();
+        String toDisplay = ldt.format(dtf) + "- " + notification + "\n\n";
+        logs.append(toDisplay);
+        setLblNotificationText(toDisplay);
     }
 
     /**
@@ -39,29 +59,10 @@ public class NotificationBarComponentController {
      * in the notification, shows a hyperlink which allows the user to expand and see
      * the entire message.
      */
-    public void setLblNotificationText(String errMessage) {
-        String[] lines = errMessage.split("\n");
+    private void setLblNotificationText(String notification) {
+        String[] lines = notification.split("\n");
 
-        // Creates an image of the given text, this is done to compare the width of the text with the width of the label.
-        Text textNode = new Text(lines[0] + " expand");
-        textNode.snapshot(null,null);
         lblNotification.setText(lines[0]);
-
-        if ((textNode.getLayoutBounds().getWidth() - 70 > grdParent.getWidth()) || lines.length > 1) {
-            addExpandHyperLinkToLabel(errMessage);
-        }
-        else{
-            removeExpandLabel();
-        }
-    }
-
-    /**
-     * Removes the expand hyperLink from the screen if it exists.
-     */
-    private void removeExpandLabel(){
-        if(!hBoxExpand.getChildren().isEmpty()){
-            hBoxExpand.getChildren().remove(0);
-        }
     }
 
     /**
@@ -71,7 +72,7 @@ public class NotificationBarComponentController {
         // Create the hyperlink that creates the error window when clicked.
         Hyperlink expandLink = new Hyperlink("expand");
         expandLink.minWidth(expandLink.getWidth());
-        expandLink.setOnAction(event -> showNotificationWindow(text));
+        expandLink.setOnAction(event -> showLogWindow(logs.toString()));
         VBox vBox = new VBox(expandLink);
         VBox.setMargin(expandLink, new Insets(5, 0, 0, 0));
         // Set a bit of space between the label and the hyperlink
@@ -87,15 +88,15 @@ public class NotificationBarComponentController {
     /**
      * Opens a window containing the entire given notification
      */
-    private void showNotificationWindow(String notification) {
+    private void showLogWindow(String logs) {
         try {
             Stage stage = new Stage();
-            stage.setTitle("Notification");
+            stage.setTitle("Program logs");
             FXMLLoader fxmlLoader = new FXMLLoader();
-            URL url = getClass().getResource("window/NotificationWindow.fxml");
+            URL url = getClass().getResource("window/LogWindow.fxml");
             Parent root = fxmlLoader.load(url.openStream());
-            NotificationWindowController controller = fxmlLoader.getController();
-            controller.initialize(notification);
+            LogWindowController controller = fxmlLoader.getController();
+            controller.initialize(logs);
             Scene scene = new Scene(root);
             stage.setScene(scene);
             stage.show();

--- a/UI/src/gui/notification/window/LogWindow.fxml
+++ b/UI/src/gui/notification/window/LogWindow.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 
-<GridPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gui.notification.window.NotificationWindowController">
+<GridPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gui.notification.window.LogWindowController">
   <columnConstraints>
     <ColumnConstraints hgrow="NEVER" minWidth="10.0" prefWidth="10.0" />
     <ColumnConstraints hgrow="ALWAYS" minWidth="-Infinity" prefWidth="400.0" />

--- a/UI/src/gui/notification/window/LogWindowController.java
+++ b/UI/src/gui/notification/window/LogWindowController.java
@@ -13,4 +13,8 @@ public class LogWindowController {
         taNotificationDisplay.setText(text);
     }
 
+    public void changeTextAreaText(String text){
+        taNotificationDisplay.setText(text);
+    }
+
 }

--- a/UI/src/gui/notification/window/LogWindowController.java
+++ b/UI/src/gui/notification/window/LogWindowController.java
@@ -3,7 +3,7 @@ package gui.notification.window;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
 
-public class NotificationWindowController {
+public class LogWindowController {
 
     @FXML
     private TextArea taNotificationDisplay;

--- a/UI/src/gui/simulation/breakdown/details/rule/activation/ActivationDetailsController.java
+++ b/UI/src/gui/simulation/breakdown/details/rule/activation/ActivationDetailsController.java
@@ -1,7 +1,6 @@
 package gui.simulation.breakdown.details.rule.activation;
 
 import engine2ui.simulation.genral.impl.properties.DTORule;
-import engine2ui.simulation.start.DTOEnvironmentVariable;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 

--- a/UI/src/manager/EngineAgent.java
+++ b/UI/src/manager/EngineAgent.java
@@ -34,8 +34,15 @@ import java.util.*;
 public class EngineAgent {
     private final EngineInterface engine;
 
+    private boolean isFileLoaded;
+
     public EngineAgent() {
+        isFileLoaded = false;
         this.engine = new WorldManager();
+    }
+
+    public boolean isFileLoaded() {
+        return isFileLoaded;
     }
 
     /**
@@ -61,6 +68,7 @@ public class EngineAgent {
 
         // TODO: Change this to a graphical user notification
         if (dtoLoadSucceed.isSucceed()) {
+            isFileLoaded = true;
             Console.println("The simulation creation has completed successfully");
             engine.resetEngine();
         } else {


### PR DESCRIPTION
- Converted the notification window to a log window.
- Fixed some problems with the execution screen:
      - Now new notifications won't generate if they don't change 
         anything (for example setting an entity's population to 0 if 
         its already 0).
      - If you press clear or start if a file is not loaded nothing will 
        happen.

**The new log window works as follows**
every event in the system that requires a notification will now also have a date time tiemstamp. The newer logs will be displayed in the top of the log window. New logs will be added even if the log window is already open