### PR TITLE
Adjust simulation runtime

### DIFF
--- a/Engine/src/jaxb/unmarshal/converter/PRDConverter.java
+++ b/Engine/src/jaxb/unmarshal/converter/PRDConverter.java
@@ -474,7 +474,7 @@ public class PRDConverter {
     private int getCountFromPRDSecondaryEntity(PRDAction.PRDSecondaryEntity prdSecondaryEntity) {
         String count = prdSecondaryEntity.getPRDSelection().getCount();
         if (count.equals("ALL")) {
-            return entities.get(prdSecondaryEntity.getEntity()).getStartingPopulation();
+            return -1;
         }
 
         return Integer.parseInt(count);

--- a/Engine/src/jaxb/unmarshal/converter/PRDConverter.java
+++ b/Engine/src/jaxb/unmarshal/converter/PRDConverter.java
@@ -418,7 +418,7 @@ public class PRDConverter {
                     ret = new KillAction(ActionType.KILL, null, prdAction.getEntity(), secondaryEntity); // Secondary entity will always be null in this case
                     break;
                 case REPLACE:
-                    ret = new ReplaceAction(null, prdAction.getKill(), prdAction.getCreate(), secondaryEntity, ReplaceActionType.valueOf(prdAction.getMode().toUpperCase()));
+                    ret = new ReplaceAction(null, prdAction.getKill(), entities.get(prdAction.getCreate()), secondaryEntity, ReplaceActionType.valueOf(prdAction.getMode().toUpperCase()));
                     break;
                 case PROXIMITY:
                     ret = getProximityActionObject(prdAction, secondaryEntity);

--- a/Engine/src/simulation/objects/entity/Entity.java
+++ b/Engine/src/simulation/objects/entity/Entity.java
@@ -94,6 +94,13 @@ public class Entity implements Serializable {
         return propertyMap;
     }
 
+    public EntityInstance createNewEntityInstance() {
+        EntityInstance ret = new EntityInstance(generateProperties(), this);
+
+        entityInstances.add(ret);
+        return ret;
+    }
+
     @Override
     public int hashCode() {
         return name.length() * startingPopulation * properties.size();
@@ -107,19 +114,36 @@ public class Entity implements Serializable {
      * @param action      The action to invoke on all instances.
      * @param probability The probability of this action to invoke on instances.
      */
-    public void invokeActionOnAllInstances(Action action, double probability, int lastChangTickCount) {
-        Random r = new Random();
-        for (EntityInstance e : entityInstances
-        ) {
-            if (r.nextDouble() <= probability && e.isAlive()) {
-                if (action.getClass().getSuperclass() == OneEntAction.class) {
-                    ((OneEntAction) action).invoke(e, lastChangTickCount);
-                } else {
-                    //Todo : implement this.
-                }
+//    public void invokeActionsOnAllInstances(List<Action> actionsToInvoke, int lastChangTickCount) {
+//        for (EntityInstance e : entityInstances) {
+//            if (e.isAlive()) {
+//                invokeActionsOnSingleInstance(e, actionsToInvoke, lastChangTickCount);
+//            }
+//        }
+//    }
+//
+//    private void invokeActionsOnSingleInstance(EntityInstance entityInstance, List<Action> actionsToInvoke, int lastChangTickCount) {
+//        for (Action action : actionsToInvoke){
+//            if(action.getContextEntity().equals(name)){
+//                if(action.getSecondaryEntity() != null) {
+//
+//                }
+//                else {
+//                    if (action.getClass().getSuperclass() == OneEntAction.class) {
+//                        ((OneEntAction) action).invoke(entityInstance, lastChangTickCount);
+//                    } else {
+//                        //Todo : implement this.
+//                    }
+//                }
+//            }
+//        }
+//    }
 
-            }
-        }
+    public EntityInstance getRandomEntityInstance() {
+        Random random = new Random();
+        int randomIndex = random.nextInt(entityInstances.size());
+
+        return entityInstances.get(randomIndex);
     }
 
     @Override

--- a/Engine/src/simulation/objects/entity/EntityInstance.java
+++ b/Engine/src/simulation/objects/entity/EntityInstance.java
@@ -43,6 +43,8 @@ public class EntityInstance implements Serializable {
     public void updateDerivedEntityInstance(EntityInstance killedInstance, int lastChangeTickCount) {
         Property newInstanceProperty;
 
+        row = killedInstance.row;
+        column = killedInstance.column;
         for (Property killedInstanceProperty : killedInstance.getProperties().values()) {
             newInstanceProperty = properties.get(killedInstanceProperty.getName());
             if(newInstanceProperty != null && newInstanceProperty.getType() == killedInstanceProperty.getType()) {

--- a/Engine/src/simulation/objects/world/World.java
+++ b/Engine/src/simulation/objects/world/World.java
@@ -39,8 +39,8 @@ public class World implements Serializable {
     private long startingTime;
     private final int threadCount;
     private final Grid grid;
-
     private int totalPopulation;
+    private final int constAll = -1;
 
     public World(Map<String, Property> environmentProperties, Map<String, Entity> entities, Map<String, Rule> rules, Map<EndingConditionType, EndingCondition> endingConditions, TicksCounter ticksCounter, Grid grid, int threadCount) {
         this.environmentProperties = environmentProperties;
@@ -157,16 +157,24 @@ public class World implements Serializable {
             for (Rule r : rules.values()) {
                 actionsToInvoke.addAll(r.getActionsToInvoke());
             }
-
+            // Invoke actions on the simulation entities.
             for (Entity entity : entities.values()) {
                 invokeActionsOnAllInstances(entity.getEntityInstances(), actionsToInvoke);
             }
+
+
         } while ((!endingConditionsMet()));
 
         DTOCreator dtoCreator = new DTOCreator();
         return new ResultData(dtoCreator.convertEntities2DTOEntities(entities));
     }
 
+    /**
+     * Invoke the given actions on each entity instance of a specific entity.
+     *
+     * @param entityInstances A specific entity instances
+     * @param actionsToInvoke List of invokable actions.
+     */
     private void invokeActionsOnAllInstances(List<EntityInstance> entityInstances, List<Action> actionsToInvoke) {
         for (EntityInstance e : entityInstances) {
             if (e.isAlive()) {
@@ -175,6 +183,9 @@ public class World implements Serializable {
         }
     }
 
+    /**
+     * 'invokeActionsOnAllInstances' helper, invoke the list of action on a specific entity instance.
+     */
     private void invokeActionsOnSingleInstance(EntityInstance entityInstance, List<Action> actionsToInvoke) {
         for (Action action : actionsToInvoke){
             if(action.getContextEntity().equals(entityInstance.getInstanceEntityName())){
@@ -206,6 +217,9 @@ public class World implements Serializable {
         }
     }
 
+    /**
+     * Getting the secondary entity instances list and invoke the action on each secondary entity instance and the primary entity instance.
+     */
     private void invokeActionsWithSecondaryEntity(EntityInstance entityInstance, Action actionToInvoke) {
         List<EntityInstance> secondaryInstances = getSecondaryInstances(actionToInvoke.getSecondaryEntity());
 
@@ -229,13 +243,16 @@ public class World implements Serializable {
         }
     }
 
+    /**
+     * Calculate the secondary entity instances create a list with the instances and return this list.
+     */
     private List<EntityInstance> getSecondaryInstances(AbstractAction.SecondaryEntity secondaryEntity) {
         List<EntityInstance> entityInstances = new ArrayList<>();
         AbstractConditionAction conditionAction = (AbstractConditionAction)secondaryEntity.getCondition();
         Entity secondaryEntityRef = entities.get(secondaryEntity.getContextEntity());
         int count = secondaryEntity.getCount();
 
-        if(count == -1){
+        if(count == constAll){
             entityInstances.addAll(secondaryEntityRef.getEntityInstances());
         }
         else {

--- a/Engine/src/simulation/objects/world/World.java
+++ b/Engine/src/simulation/objects/world/World.java
@@ -11,6 +11,7 @@ import simulation.objects.world.ticks.counter.TicksCounter;
 import simulation.properties.action.api.AbstractAction;
 import simulation.properties.action.api.Action;
 import simulation.properties.action.api.OneEntAction;
+import simulation.properties.action.impl.calculation.CalculationAction;
 import simulation.properties.action.impl.condition.AbstractConditionAction;
 import simulation.properties.action.impl.condition.SingleCondition;
 import simulation.properties.action.impl.proximity.ProximityAction;
@@ -189,7 +190,10 @@ public class World implements Serializable {
 
     private void invokeAnAction(EntityInstance entityInstance, Action action) {
         if (action.getClass().getSuperclass() == OneEntAction.class) {
-            ((OneEntAction) action).invoke(entityInstance, ticks.getTicks());
+            ((OneEntAction) action).invoke(entityInstance, false, ticks.getTicks());
+        } else if (action instanceof CalculationAction) {
+            CalculationAction calculationAction = (CalculationAction)action;
+            calculationAction.invoke(entityInstance, false, false, ticks.getTicks());
         } else if (action instanceof AbstractConditionAction) {
             AbstractConditionAction abstractConditionAction = (AbstractConditionAction)action;
             abstractConditionAction.invoke(entityInstance, grid, ticks.getTicks());
@@ -206,12 +210,21 @@ public class World implements Serializable {
         List<EntityInstance> secondaryInstances = getSecondaryInstances(actionToInvoke.getSecondaryEntity());
 
         for(EntityInstance secondaryEntityInstance : secondaryInstances) {
-            if(actionToInvoke instanceof AbstractConditionAction) {
-                AbstractConditionAction abstractConditionAction = (AbstractConditionAction)actionToInvoke;
+            if(actionToInvoke instanceof OneEntAction){
+                OneEntAction oneEntAction = (OneEntAction)actionToInvoke;
+                oneEntAction.invokeWithSecondary(entityInstance, secondaryEntityInstance, ticks.getTicks());
+            } else if (actionToInvoke instanceof CalculationAction) {
+                CalculationAction calculationAction = (CalculationAction)actionToInvoke;
+                calculationAction.invokeWithSecondary(entityInstance,secondaryEntityInstance, ticks.getTicks());
+            } else if (actionToInvoke instanceof AbstractConditionAction) {
+                AbstractConditionAction abstractConditionAction = (AbstractConditionAction) actionToInvoke;
                 abstractConditionAction.invokeWithSecondary(entityInstance, secondaryEntityInstance, grid, ticks.getTicks());
-            }
-            else {
-                //Todo: implement after Aviad's response.
+            } else if(actionToInvoke instanceof ProximityAction) {
+                ProximityAction proximityAction = (ProximityAction)actionToInvoke;
+                proximityAction.invokeWithSecondary(entityInstance, secondaryEntityInstance, grid, ticks.getTicks());
+            } else if(actionToInvoke instanceof ReplaceAction) {
+                ReplaceAction replaceAction = (ReplaceAction)actionToInvoke;
+                replaceAction.invokeWithSecondary(entityInstance, secondaryEntityInstance, grid, ticks.getTicks());
             }
         }
     }

--- a/Engine/src/simulation/objects/world/grid/Grid.java
+++ b/Engine/src/simulation/objects/world/grid/Grid.java
@@ -31,6 +31,10 @@ public class Grid {
         return columns;
     }
 
+    public void setInstanceInGrid(int row, int column, EntityInstance instance) {
+        grid[row][column] = instance;
+    }
+
     /**
      * Iterates through the grid and tries to move around all entities.
      */

--- a/Engine/src/simulation/properties/action/api/AbstractAction.java
+++ b/Engine/src/simulation/properties/action/api/AbstractAction.java
@@ -46,7 +46,7 @@ public abstract class AbstractAction implements Action {
 
     public static class SecondaryEntity{
         protected final String contextEntity;
-        private final int count;
+        private final int count; // If count value is -1 -> Got 'All' from the PRDSelection.
         private final Action Condition;
 
         public SecondaryEntity(String contextEntity, int count, Action condition) {

--- a/Engine/src/simulation/properties/action/api/AbstractAction.java
+++ b/Engine/src/simulation/properties/action/api/AbstractAction.java
@@ -79,30 +79,94 @@ public abstract class AbstractAction implements Action {
                 ((TicksExpression)expression).setProperty(instanceProperty);
             } else if (expression instanceof EvaluateExpression) {
                 ((EvaluateExpression)expression).setProperty(instanceProperty);
+            } else if (expression instanceof PercentExpression) {
+                updatePercentExpressionWithOneInstance(entityInstance, (PercentExpression)expression);
             }
         }
     }
 
-    // Todo: find where to use this.
-    protected void updatePercentExpression(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, PercentExpression percentExpression) {
+    /**
+     * The method return true if the expression updated, if not, return false.
+     */
+    protected boolean updateExpressionWithSecondary(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Expression expression) {
+        String propertyName;
+        Property instanceProperty;
+        boolean ret = false;
+
+        if(expression instanceof PercentExpression) {
+            updatePercentExpressionWithSecondInstance(firstEntityInstance, secondEntityInstance, (PercentExpression)expression);
+            ret = true;
+        } else if (expression instanceof EvaluateExpression) {
+            EvaluateExpression evaluateExpression = (EvaluateExpression)expression;
+            if(evaluateExpression.getEntityName().equals(firstEntityInstance.getInstanceEntityName())) {
+                propertyName = ((Property)getContextProperty().evaluate()).getName();
+                instanceProperty = firstEntityInstance.getPropertyByName(propertyName);
+                evaluateExpression.setProperty(instanceProperty);
+                ret = true;
+            }
+            else {
+                propertyName = ((Property)getContextProperty().evaluate()).getName();
+                instanceProperty = secondEntityInstance.getPropertyByName(propertyName);
+                evaluateExpression.setProperty(instanceProperty);
+                ret = true;
+            }
+        } else if (expression instanceof TicksExpression) {
+            TicksExpression ticksExpression = (TicksExpression)expression;
+            if(ticksExpression.getEntityName().equals(firstEntityInstance.getInstanceEntityName())) {
+                propertyName = ((Property)getContextProperty().evaluate()).getName();
+                instanceProperty = firstEntityInstance.getPropertyByName(propertyName);
+                ticksExpression.setProperty(instanceProperty);
+                ret = true;
+            }
+            else {
+                propertyName = ((Property)getContextProperty().evaluate()).getName();
+                instanceProperty = secondEntityInstance.getPropertyByName(propertyName);
+                ticksExpression.setProperty(instanceProperty);
+                ret = true;
+            }
+        }
+
+        return ret;
+    }
+
+    protected void updatePercentExpressionWithOneInstance(EntityInstance entityInstance, PercentExpression percentExpression) {
         Expression exp1 = percentExpression.getArg1(), exp2 = percentExpression.getArg2();
 
         if (exp1 instanceof PercentExpression){
-            updatePercentExpression(firstEntityInstance, secondEntityInstance, (PercentExpression)exp1);
+            updatePercentExpressionWithOneInstance(entityInstance, (PercentExpression)exp1);
         }
         else {
-            updateSubExpression(firstEntityInstance, secondEntityInstance, exp1);
+            updateExpression(entityInstance, exp1);
         }
 
         if(exp2 instanceof PercentExpression){
-            updatePercentExpression(firstEntityInstance, secondEntityInstance, (PercentExpression)exp2);
+            updatePercentExpressionWithOneInstance(entityInstance, (PercentExpression)exp2);
         }
         else {
-            updateSubExpression(firstEntityInstance, secondEntityInstance, exp2);
+            updateExpression(entityInstance, exp2);
         }
     }
 
-    private void updateSubExpression(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Expression expression){
+    // Todo: find where to use this.
+    protected void updatePercentExpressionWithSecondInstance(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, PercentExpression percentExpression) {
+        Expression exp1 = percentExpression.getArg1(), exp2 = percentExpression.getArg2();
+
+        if (exp1 instanceof PercentExpression){
+            updatePercentExpressionWithSecondInstance(firstEntityInstance, secondEntityInstance, (PercentExpression)exp1);
+        }
+        else {
+            updateSubExpressionWithSecondInstance(firstEntityInstance, secondEntityInstance, exp1);
+        }
+
+        if(exp2 instanceof PercentExpression){
+            updatePercentExpressionWithSecondInstance(firstEntityInstance, secondEntityInstance, (PercentExpression)exp2);
+        }
+        else {
+            updateSubExpressionWithSecondInstance(firstEntityInstance, secondEntityInstance, exp2);
+        }
+    }
+
+    private void updateSubExpressionWithSecondInstance(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Expression expression){
         String expressionEntityName = getEntityNameIfEvalOrTicksOrRegularProperty(expression);
 
         if(expressionEntityName != null){

--- a/Engine/src/simulation/properties/action/api/OneEntAction.java
+++ b/Engine/src/simulation/properties/action/api/OneEntAction.java
@@ -13,4 +13,5 @@ public abstract class OneEntAction extends AbstractAction implements Action, Ser
     }
 
     abstract public void invoke(EntityInstance entityInstance, int lastChangeTickCount);
+
 }

--- a/Engine/src/simulation/properties/action/api/OneEntAction.java
+++ b/Engine/src/simulation/properties/action/api/OneEntAction.java
@@ -1,17 +1,17 @@
 package simulation.properties.action.api;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.expression.api.Expression;
 
 import java.io.Serializable;
 
 public abstract class OneEntAction extends AbstractAction implements Action, Serializable {
-
-
     public OneEntAction(ActionType type, Expression contextProperty, String contextEntity, SecondaryEntity secondaryEntity) {
         super(type, contextProperty, contextEntity, secondaryEntity);
     }
 
-    abstract public void invoke(EntityInstance entityInstance, int lastChangeTickCount);
+    abstract public void invoke(EntityInstance entityInstance, boolean isExpressionUpdated, int lastChangeTickCount);
 
+    abstract public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, int lastChangeTickCount);
 }

--- a/Engine/src/simulation/properties/action/impl/DecreaseAction.java
+++ b/Engine/src/simulation/properties/action/impl/DecreaseAction.java
@@ -1,9 +1,13 @@
 package simulation.properties.action.impl;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.OneEntAction;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
+import simulation.properties.action.expression.impl.methods.EvaluateExpression;
+import simulation.properties.action.expression.impl.methods.PercentExpression;
+import simulation.properties.action.expression.impl.methods.TicksExpression;
 import simulation.properties.property.api.Property;
 
 import java.io.Serializable;
@@ -32,7 +36,7 @@ public class DecreaseAction extends OneEntAction implements Serializable {
      * @param entityInstance The given entity to decrease the value of the action's property from.
      */
     @Override
-    public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, boolean isExpressionUpdated, int lastChangeTickCount) {
         String propertyName = ((Property)getContextProperty().evaluate()).getName();
         Property toDecrease = entityInstance.getPropertyByName(propertyName);
 
@@ -40,7 +44,10 @@ public class DecreaseAction extends OneEntAction implements Serializable {
             return;
         }
 
-        updateExpression(entityInstance, value);
+        if (!isExpressionUpdated){
+            updateExpression(entityInstance, value);
+        }
+
         switch (toDecrease.getType())
         {
             case DECIMAL:
@@ -52,5 +59,19 @@ public class DecreaseAction extends OneEntAction implements Serializable {
         }
     }
 
+    @Override
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, int lastChangeTickCount) {
+        EntityInstance instanceForInvoke;
+        boolean isExpressionUpdated;
 
+        if(getContextEntity().equals(primaryInstance.getInstanceEntityName())){
+            instanceForInvoke = primaryInstance;
+        }
+        else {
+            instanceForInvoke = secondaryInstance;
+        }
+
+        isExpressionUpdated = updateExpressionWithSecondary(primaryInstance, secondaryInstance, value);
+        invoke(instanceForInvoke, isExpressionUpdated, lastChangeTickCount);
+    }
 }

--- a/Engine/src/simulation/properties/action/impl/DecreaseAction.java
+++ b/Engine/src/simulation/properties/action/impl/DecreaseAction.java
@@ -51,4 +51,6 @@ public class DecreaseAction extends OneEntAction implements Serializable {
                 break;
         }
     }
+
+
 }

--- a/Engine/src/simulation/properties/action/impl/IncreaseAction.java
+++ b/Engine/src/simulation/properties/action/impl/IncreaseAction.java
@@ -51,4 +51,6 @@ public class IncreaseAction extends OneEntAction implements Serializable {
                 break;
         }
     }
+
+
 }

--- a/Engine/src/simulation/properties/action/impl/IncreaseAction.java
+++ b/Engine/src/simulation/properties/action/impl/IncreaseAction.java
@@ -1,9 +1,11 @@
 package simulation.properties.action.impl;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.OneEntAction;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
+import simulation.properties.action.expression.impl.methods.PercentExpression;
 import simulation.properties.property.api.Property;
 
 import java.io.Serializable;
@@ -32,7 +34,7 @@ public class IncreaseAction extends OneEntAction implements Serializable {
      * @param entityInstance The given entity to increase the value of the action's property.
      */
     @Override
-    public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, boolean isExpressionUpdated, int lastChangeTickCount) {
         String propertyName = ((Property)getContextProperty().evaluate()).getName();
         Property toIncrease = entityInstance.getPropertyByName(propertyName);
 
@@ -40,7 +42,10 @@ public class IncreaseAction extends OneEntAction implements Serializable {
             return;
         }
 
-        updateExpression(entityInstance, value);
+        if (!isExpressionUpdated){
+            updateExpression(entityInstance, value);
+        }
+
         switch (toIncrease.getType())
         {
             case DECIMAL:
@@ -52,5 +57,19 @@ public class IncreaseAction extends OneEntAction implements Serializable {
         }
     }
 
+    @Override
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, int lastChangeTickCount) {
+        EntityInstance instanceForInvoke;
+        boolean isExpressionUpdated;
 
+        if(getContextEntity().equals(primaryInstance.getInstanceEntityName())){
+            instanceForInvoke = primaryInstance;
+        }
+        else {
+            instanceForInvoke = secondaryInstance;
+        }
+
+        isExpressionUpdated = updateExpressionWithSecondary(primaryInstance, secondaryInstance, value);
+        invoke(instanceForInvoke, isExpressionUpdated, lastChangeTickCount);
+    }
 }

--- a/Engine/src/simulation/properties/action/impl/KillAction.java
+++ b/Engine/src/simulation/properties/action/impl/KillAction.java
@@ -26,4 +26,7 @@ public class KillAction extends OneEntAction implements Serializable {
     public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
         entityInstance.kill();
     }
+
+
 }
+

--- a/Engine/src/simulation/properties/action/impl/KillAction.java
+++ b/Engine/src/simulation/properties/action/impl/KillAction.java
@@ -1,6 +1,7 @@
 package simulation.properties.action.impl;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.OneEntAction;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
@@ -23,10 +24,22 @@ public class KillAction extends OneEntAction implements Serializable {
     }
 
     @Override
-    public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, boolean isExpressionUpdated, int lastChangeTickCount) {
         entityInstance.kill();
     }
 
+    @Override
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, int lastChangeTickCount) {
+        EntityInstance instanceForInvoke;
 
+        if(getContextEntity().equals(primaryInstance.getInstanceEntityName())){
+            instanceForInvoke = primaryInstance;
+        }
+        else {
+            instanceForInvoke = secondaryInstance;
+        }
+
+        invoke(instanceForInvoke, true, lastChangeTickCount);
+    }
 }
 

--- a/Engine/src/simulation/properties/action/impl/SetAction.java
+++ b/Engine/src/simulation/properties/action/impl/SetAction.java
@@ -1,9 +1,11 @@
 package simulation.properties.action.impl;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.OneEntAction;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
+import simulation.properties.action.expression.impl.methods.PercentExpression;
 import simulation.properties.property.api.Property;
 
 import java.io.Serializable;
@@ -27,15 +29,33 @@ public class SetAction extends OneEntAction implements Serializable {
     }
 
     @Override
-    public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, boolean isExpressionUpdated, int lastChangeTickCount) {
         String propertyName = ((Property)getContextProperty().evaluate()).getName();
         Property toSet = entityInstance.getPropertyByName(propertyName);
         if(toSet == null){
             return;
         }
 
-        updateExpression(entityInstance, value);
+        if (!isExpressionUpdated){
+            updateExpression(entityInstance, value);
+        }
+
         toSet.setValue(value.evaluate(), lastChangeTickCount);
     }
 
+    @Override
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, int lastChangeTickCount) {
+        EntityInstance instanceForInvoke;
+        boolean isExpressionUpdated;
+
+        if(getContextEntity().equals(primaryInstance.getInstanceEntityName())){
+            instanceForInvoke = primaryInstance;
+        }
+        else {
+            instanceForInvoke = secondaryInstance;
+        }
+
+        isExpressionUpdated = updateExpressionWithSecondary(primaryInstance, secondaryInstance, value);
+        invoke(instanceForInvoke, isExpressionUpdated, lastChangeTickCount);
+    }
 }

--- a/Engine/src/simulation/properties/action/impl/SetAction.java
+++ b/Engine/src/simulation/properties/action/impl/SetAction.java
@@ -37,4 +37,5 @@ public class SetAction extends OneEntAction implements Serializable {
         updateExpression(entityInstance, value);
         toSet.setValue(value.evaluate(), lastChangeTickCount);
     }
+
 }

--- a/Engine/src/simulation/properties/action/impl/calculation/CalculationAction.java
+++ b/Engine/src/simulation/properties/action/impl/calculation/CalculationAction.java
@@ -87,4 +87,5 @@ public class CalculationAction extends OneEntAction implements Serializable {
                 break;
         }
     }
+
 }

--- a/Engine/src/simulation/properties/action/impl/condition/AbstractConditionAction.java
+++ b/Engine/src/simulation/properties/action/impl/condition/AbstractConditionAction.java
@@ -87,4 +87,9 @@ public abstract class AbstractConditionAction extends OneEntAction implements Se
         }
         isTrue = false;
     }
+
+    public Boolean getConditionResult(EntityInstance entityInstance) {
+        this.invoke(entityInstance, 0);
+        return isTrue;
+    }
 }

--- a/Engine/src/simulation/properties/action/impl/condition/AbstractConditionAction.java
+++ b/Engine/src/simulation/properties/action/impl/condition/AbstractConditionAction.java
@@ -2,16 +2,15 @@ package simulation.properties.action.impl.condition;
 
 import jaxb.schema.generated.PRDAction;
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
+import simulation.properties.action.api.*;
 import simulation.properties.action.api.OneEntAction;
-import simulation.properties.action.api.Action;
-import simulation.properties.action.api.OneEntAction;
-import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
 
 import java.io.Serializable;
 
 
-public abstract class AbstractConditionAction extends OneEntAction implements Serializable {
+public abstract class AbstractConditionAction extends AbstractAction implements Serializable {
     protected Expression value;
     protected boolean isTrue;
     protected final ThenOrElse thenActions;
@@ -69,9 +68,16 @@ public abstract class AbstractConditionAction extends OneEntAction implements Se
      * If this is activated then this condition must be true.
      * @param entityInstance The given entity to invoke all "thenActions" upon.
      */
-    protected void invokeThenActions(EntityInstance entityInstance, int lastChangTickCount){
+    protected void invokeThenActions(EntityInstance entityInstance, Grid grid, int lastChangTickCount){
         if(thenActions != null){
-            thenActions.invoke(entityInstance, lastChangTickCount);
+            thenActions.invoke(entityInstance, grid, lastChangTickCount);
+        }
+        isTrue = true;
+    }
+
+    protected void invokeThenActionsWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount) {
+        if(thenActions != null){
+            thenActions.invokeWithSecondary(primaryInstance, secondaryInstance, grid, lastChangeTickCount);
         }
         isTrue = true;
     }
@@ -81,15 +87,26 @@ public abstract class AbstractConditionAction extends OneEntAction implements Se
      * If this is activated then this condition must be true.
      * @param entityInstance The given entity to invoke all "elseActions" upon.
      */
-    protected void invokeElseActions(EntityInstance entityInstance, int lastChangTickCount){
+    protected void invokeElseActions(EntityInstance entityInstance, Grid grid, int lastChangTickCount){
         if(elseActions != null) {
-            elseActions.invoke(entityInstance, lastChangTickCount);
+            elseActions.invoke(entityInstance, grid, lastChangTickCount);
+        }
+        isTrue = false;
+    }
+
+    protected void invokeElseActionsWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount) {
+        if(elseActions != null){
+            elseActions.invokeWithSecondary(primaryInstance, secondaryInstance, grid, lastChangeTickCount);
         }
         isTrue = false;
     }
 
     public Boolean getConditionResult(EntityInstance entityInstance) {
-        this.invoke(entityInstance, 0);
+        this.invoke(entityInstance, null, 0);
         return isTrue;
     }
+
+    abstract public void invoke(EntityInstance entityInstance, Grid grid, int lastChangeTickCount);
+
+    abstract public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount);
 }

--- a/Engine/src/simulation/properties/action/impl/condition/SingleCondition.java
+++ b/Engine/src/simulation/properties/action/impl/condition/SingleCondition.java
@@ -1,6 +1,7 @@
 package simulation.properties.action.impl.condition;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
 import simulation.properties.action.expression.impl.PropertyValueExpression;
@@ -30,7 +31,7 @@ public class SingleCondition extends AbstractConditionAction implements Serializ
     }
 
     @Override
-    public void invoke(EntityInstance entityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, Grid grid, int lastChangeTickCount) {
         Object valueToCompare;
 
         updateExpression(entityInstance, contextProperty);
@@ -44,16 +45,16 @@ public class SingleCondition extends AbstractConditionAction implements Serializ
             // These 2 operators don;t require casting for comparison
             case EQUALS:
                 if (valueToCompare == getValue()) {
-                    invokeThenActions(entityInstance, lastChangeTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangeTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangeTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangeTickCount);
                 }
                 break;
             case NOT_EQUALS:
                 if (valueToCompare != getValue()) {
-                    invokeThenActions(entityInstance, lastChangeTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangeTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangeTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangeTickCount);
                 }
                 break;
                 // For Lt & Bt we do require casting, it is handled in these funcs.
@@ -61,50 +62,55 @@ public class SingleCondition extends AbstractConditionAction implements Serializ
             default:
                 switch (contextProperty.getType()){
                     case DECIMAL:
-                        compareInequalityByInteger(valueToCompare, entityInstance, lastChangeTickCount);
+                        compareInequalityByInteger(valueToCompare, entityInstance, grid, lastChangeTickCount);
                         break;
                     case FLOAT:
-                        compareInequalityByFloat(valueToCompare, entityInstance, lastChangeTickCount);
+                        compareInequalityByFloat(valueToCompare, entityInstance, grid, lastChangeTickCount);
                         break;
                 }
         }
     }
 
-    private void compareInequalityByInteger(Object toCompare, EntityInstance entityInstance, int lastChangTickCount){
+    private void compareInequalityByInteger(Object toCompare, EntityInstance entityInstance, Grid grid, int lastChangTickCount){
         switch (operator) {
             case BIGGER_THAN:
                 if ((int) toCompare > (int) getValue()) {
-                    invokeThenActions(entityInstance, lastChangTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangTickCount);
                 }
                 break;
             case LESSER_THAN:
                 if ((int) toCompare < (int) getValue()) {
-                    invokeThenActions(entityInstance, lastChangTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangTickCount);
                 }
                 break;
         }
     }
 
-    private void compareInequalityByFloat(Object toCompare, EntityInstance entityInstance, int lastChangTickCount){
+    private void compareInequalityByFloat(Object toCompare, EntityInstance entityInstance, Grid grid, int lastChangTickCount){
         switch (operator) {
             case BIGGER_THAN:
                 if ((double) toCompare > (double) getValue()) {
-                    invokeThenActions(entityInstance, lastChangTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangTickCount);
                 }
                 break;
             case LESSER_THAN:
                 if ((double) toCompare < (double) getValue()) {
-                    invokeThenActions(entityInstance, lastChangTickCount);
+                    invokeThenActions(entityInstance, grid, lastChangTickCount);
                 } else {
-                    invokeElseActions(entityInstance, lastChangTickCount);
+                    invokeElseActions(entityInstance, grid, lastChangTickCount);
                 }
                 break;
         }
+    }
+
+    @Override
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount) {
+
     }
 }

--- a/Engine/src/simulation/properties/action/impl/condition/ThenOrElse.java
+++ b/Engine/src/simulation/properties/action/impl/condition/ThenOrElse.java
@@ -4,6 +4,7 @@ import simulation.objects.entity.EntityInstance;
 import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.Action;
 import simulation.properties.action.api.OneEntAction;
+import simulation.properties.action.impl.calculation.CalculationAction;
 import simulation.properties.action.impl.proximity.ProximityAction;
 import simulation.properties.action.impl.replace.ReplaceAction;
 
@@ -22,34 +23,43 @@ public class ThenOrElse implements Serializable {
     }
 
     public void invoke(EntityInstance entityInstance, Grid grid, int lastChangTickCount){
-        for (Action a: actionsToInvoke) {
-            invokeAnAction(a, entityInstance, grid, lastChangTickCount);
-        }
-    }
-
-    private void invokeAnAction(Action action, EntityInstance entityInstance, Grid grid, int lastChangTickCount) {
-        if(action instanceof OneEntAction){
-            OneEntAction oneEntAction = (OneEntAction)action;
-            oneEntAction.invoke(entityInstance, lastChangTickCount);
-        } else if (action instanceof AbstractConditionAction) {
-            AbstractConditionAction abstractConditionAction = (AbstractConditionAction) action;
-            abstractConditionAction.invoke(entityInstance, grid, lastChangTickCount);
-        } else if(action instanceof ProximityAction) {
-            ProximityAction proximityAction = (ProximityAction)action;
-            proximityAction.invoke(entityInstance, grid, lastChangTickCount);
-        } else if(action instanceof ReplaceAction) {
-            ReplaceAction replaceAction = (ReplaceAction)action;
-            replaceAction.invoke(entityInstance, grid, lastChangTickCount);
+        for (Action action: actionsToInvoke) {
+            if(action instanceof OneEntAction){
+                OneEntAction oneEntAction = (OneEntAction)action;
+                oneEntAction.invoke(entityInstance, false, lastChangTickCount);
+            } else if(action instanceof CalculationAction){
+                CalculationAction calculationAction = (CalculationAction)action;
+                calculationAction.invoke(entityInstance,false,false,lastChangTickCount);
+            } else if (action instanceof AbstractConditionAction) {
+                AbstractConditionAction abstractConditionAction = (AbstractConditionAction) action;
+                abstractConditionAction.invoke(entityInstance, grid, lastChangTickCount);
+            } else if(action instanceof ProximityAction) {
+                ProximityAction proximityAction = (ProximityAction)action;
+                proximityAction.invoke(entityInstance, grid, lastChangTickCount);
+            } else if(action instanceof ReplaceAction) {
+                ReplaceAction replaceAction = (ReplaceAction)action;
+                replaceAction.invoke(entityInstance, grid, lastChangTickCount);
+            }
         }
     }
 
     public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount) {
-        for (Action a: actionsToInvoke) {
-            if(a.getContextEntity().equals(primaryInstance.getInstanceEntityName())) {
-                invokeAnAction(a, primaryInstance, grid, lastChangeTickCount);
-            }
-            else {
-                invokeAnAction(a, secondaryInstance, grid, lastChangeTickCount);
+        for (Action action: actionsToInvoke) {
+            if(action instanceof OneEntAction){
+                OneEntAction oneEntAction = (OneEntAction)action;
+                oneEntAction.invokeWithSecondary(primaryInstance, secondaryInstance, lastChangeTickCount);
+            } else if (action instanceof CalculationAction) {
+                CalculationAction calculationAction = (CalculationAction)action;
+                calculationAction.invokeWithSecondary(primaryInstance,secondaryInstance, lastChangeTickCount);
+            } else if (action instanceof AbstractConditionAction) {
+                AbstractConditionAction abstractConditionAction = (AbstractConditionAction) action;
+                abstractConditionAction.invokeWithSecondary(primaryInstance, secondaryInstance, grid, lastChangeTickCount);
+            } else if(action instanceof ProximityAction) {
+                ProximityAction proximityAction = (ProximityAction)action;
+                proximityAction.invokeWithSecondary(primaryInstance, secondaryInstance, grid, lastChangeTickCount);
+            } else if(action instanceof ReplaceAction) {
+                ReplaceAction replaceAction = (ReplaceAction)action;
+                replaceAction.invokeWithSecondary(primaryInstance, secondaryInstance, grid, lastChangeTickCount);
             }
         }
     }

--- a/Engine/src/simulation/properties/action/impl/condition/ThenOrElse.java
+++ b/Engine/src/simulation/properties/action/impl/condition/ThenOrElse.java
@@ -1,6 +1,7 @@
 package simulation.properties.action.impl.condition;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.Action;
 import simulation.properties.action.api.OneEntAction;
 import simulation.properties.action.impl.proximity.ProximityAction;
@@ -20,21 +21,35 @@ public class ThenOrElse implements Serializable {
         return actionsToInvoke.size();
     }
 
-    public void invoke(EntityInstance entityInstance, int lastChangTickCount){
-        for (Action a: actionsToInvoke
-             ) {
-            // TODO: Find a way to implement this.
-            if(a instanceof OneEntAction){
-                OneEntAction action = (OneEntAction)a;
-                //action.invoke();
+    public void invoke(EntityInstance entityInstance, Grid grid, int lastChangTickCount){
+        for (Action a: actionsToInvoke) {
+            invokeAnAction(a, entityInstance, grid, lastChangTickCount);
+        }
+    }
+
+    private void invokeAnAction(Action action, EntityInstance entityInstance, Grid grid, int lastChangTickCount) {
+        if(action instanceof OneEntAction){
+            OneEntAction oneEntAction = (OneEntAction)action;
+            oneEntAction.invoke(entityInstance, lastChangTickCount);
+        } else if (action instanceof AbstractConditionAction) {
+            AbstractConditionAction abstractConditionAction = (AbstractConditionAction) action;
+            abstractConditionAction.invoke(entityInstance, grid, lastChangTickCount);
+        } else if(action instanceof ProximityAction) {
+            ProximityAction proximityAction = (ProximityAction)action;
+            proximityAction.invoke(entityInstance, grid, lastChangTickCount);
+        } else if(action instanceof ReplaceAction) {
+            ReplaceAction replaceAction = (ReplaceAction)action;
+            replaceAction.invoke(entityInstance, grid, lastChangTickCount);
+        }
+    }
+
+    public void invokeWithSecondary(EntityInstance primaryInstance, EntityInstance secondaryInstance, Grid grid, int lastChangeTickCount) {
+        for (Action a: actionsToInvoke) {
+            if(a.getContextEntity().equals(primaryInstance.getInstanceEntityName())) {
+                invokeAnAction(a, primaryInstance, grid, lastChangeTickCount);
             }
-            if(a instanceof ProximityAction){
-                ProximityAction action = (ProximityAction)a;
-                //action.invoke();
-            }
-            if(a instanceof ReplaceAction){
-                ReplaceAction action = (ReplaceAction)a;
-                //action.invoke();
+            else {
+                invokeAnAction(a, secondaryInstance, grid, lastChangeTickCount);
             }
         }
     }

--- a/Engine/src/simulation/properties/action/impl/proximity/ProximityAction.java
+++ b/Engine/src/simulation/properties/action/impl/proximity/ProximityAction.java
@@ -48,20 +48,29 @@ public class ProximityAction extends AbstractAction {
         return ret;
     }
 
-    public void invoke(EntityInstance firstEntityInstance, Grid grid, int lastChangeTickCount) {
+    public void invoke(EntityInstance entityInstance, Grid grid, int lastChangeTickCount) {
         int depthValue = (int) depth.evaluate();
 
         for (int i = -depthValue; i <= depthValue; i++) {
             for (int j = -depthValue; j <= depthValue; j++) {
-                int x = adjustCoordinate((firstEntityInstance.row + i), grid.getRows());
-                int y = adjustCoordinate((firstEntityInstance.column + j), grid.getColumns());
+                int x = adjustCoordinate((entityInstance.row + i), grid.getRows());
+                int y = adjustCoordinate((entityInstance.column + j), grid.getColumns());
 
                 if (grid.getInstance(x,y) != null && grid.getInstance(x,y).getInstanceEntityName().equals(targetEntityName)) {
                     // Target entity found within the circle
-                    proximityActions.invoke(firstEntityInstance, grid.getInstance(x,y), lastChangeTickCount);
+                    proximityActions.invoke(entityInstance, grid.getInstance(x,y), grid, lastChangeTickCount);
                     break;
                 }
             }
+        }
+    }
+
+    public void invokeWithSecondary(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Grid grid, int lastChangeTickCount) {
+        if(getContextEntity().equals(firstEntityInstance.getInstanceEntityName())) {
+            invoke(firstEntityInstance, grid, lastChangeTickCount);
+        }
+        else {
+            invoke(secondEntityInstance, grid, lastChangeTickCount);
         }
     }
 

--- a/Engine/src/simulation/properties/action/impl/proximity/ProximityAction.java
+++ b/Engine/src/simulation/properties/action/impl/proximity/ProximityAction.java
@@ -48,7 +48,7 @@ public class ProximityAction extends AbstractAction {
         return ret;
     }
 
-    public void invoke(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Grid grid, int lastChangeTickCount) {
+    public void invoke(EntityInstance firstEntityInstance, Grid grid, int lastChangeTickCount) {
         int depthValue = (int) depth.evaluate();
 
         for (int i = -depthValue; i <= depthValue; i++) {
@@ -56,9 +56,9 @@ public class ProximityAction extends AbstractAction {
                 int x = adjustCoordinate((firstEntityInstance.row + i), grid.getRows());
                 int y = adjustCoordinate((firstEntityInstance.column + j), grid.getColumns());
 
-                if (grid.getInstance(x,y) == secondEntityInstance) {
+                if (grid.getInstance(x,y) != null && grid.getInstance(x,y).getInstanceEntityName().equals(targetEntityName)) {
                     // Target entity found within the circle
-                    proximityActions.invoke(firstEntityInstance, secondEntityInstance, lastChangeTickCount);
+                    proximityActions.invoke(firstEntityInstance, grid.getInstance(x,y), lastChangeTickCount);
                     break;
                 }
             }

--- a/Engine/src/simulation/properties/action/impl/proximity/ProximitySubActions.java
+++ b/Engine/src/simulation/properties/action/impl/proximity/ProximitySubActions.java
@@ -1,7 +1,12 @@
 package simulation.properties.action.impl.proximity;
 
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.Action;
+import simulation.properties.action.api.OneEntAction;
+import simulation.properties.action.impl.calculation.CalculationAction;
+import simulation.properties.action.impl.condition.AbstractConditionAction;
+import simulation.properties.action.impl.replace.ReplaceAction;
 
 import java.util.List;
 
@@ -16,9 +21,24 @@ public class ProximitySubActions {
         return actionsToInvoke.size();
     }
 
-    public void invoke(EntityInstance sourceEntityInstance, EntityInstance targetEntityInstance, int lastChangTickCount){
-        for (Action a: actionsToInvoke) {
-            // Todo: find a solution for this invoke, the actions can receive the source entity, but the value expression can be composed from the target entity property
+    public void invoke(EntityInstance sourceEntityInstance, EntityInstance targetEntityInstance, Grid grid, int lastChangTickCount){
+        for (Action action: actionsToInvoke) {
+            if(action instanceof OneEntAction){
+                OneEntAction oneEntAction = (OneEntAction)action;
+                oneEntAction.invokeWithSecondary(sourceEntityInstance, sourceEntityInstance, lastChangTickCount);
+            } else if (action instanceof CalculationAction) {
+                CalculationAction calculationAction = (CalculationAction)action;
+                calculationAction.invokeWithSecondary(sourceEntityInstance,targetEntityInstance, lastChangTickCount);
+            } else if (action instanceof AbstractConditionAction) {
+                AbstractConditionAction abstractConditionAction = (AbstractConditionAction) action;
+                abstractConditionAction.invokeWithSecondary(sourceEntityInstance, targetEntityInstance, grid, lastChangTickCount);
+            } else if(action instanceof ProximityAction) {
+                ProximityAction proximityAction = (ProximityAction)action;
+                proximityAction.invokeWithSecondary(sourceEntityInstance, targetEntityInstance, grid, lastChangTickCount);
+            } else if(action instanceof ReplaceAction) {
+                ReplaceAction replaceAction = (ReplaceAction)action;
+                replaceAction.invokeWithSecondary(sourceEntityInstance, targetEntityInstance, grid, lastChangTickCount);
+            }
         }
     }
 }

--- a/Engine/src/simulation/properties/action/impl/replace/ReplaceAction.java
+++ b/Engine/src/simulation/properties/action/impl/replace/ReplaceAction.java
@@ -1,24 +1,22 @@
 package simulation.properties.action.impl.replace;
 
+import simulation.objects.entity.Entity;
 import simulation.objects.entity.EntityInstance;
+import simulation.objects.world.grid.Grid;
 import simulation.properties.action.api.AbstractAction;
 import simulation.properties.action.api.ActionType;
 import simulation.properties.action.expression.api.Expression;
 
 public class ReplaceAction extends AbstractAction {
-    private final String newEntityName;
-
+    private final Entity newEntity;
     private final ReplaceActionType replaceType;
 
-    public ReplaceAction(Expression property, String contextEntity, String newEntityName, SecondaryEntity secondaryEntity, ReplaceActionType replaceType) {
+    public ReplaceAction(Expression property, String contextEntity, Entity newEntity, SecondaryEntity secondaryEntity, ReplaceActionType replaceType) {
         super(ActionType.REPLACE, property, contextEntity, secondaryEntity);
-        this.newEntityName = newEntityName;
+        this.newEntity = newEntity;
         this.replaceType = replaceType;
     }
 
-    public String getNewEntityName() {
-        return newEntityName;
-    }
 
     public ReplaceActionType getReplaceType() {
         return replaceType;
@@ -34,11 +32,14 @@ public class ReplaceAction extends AbstractAction {
         return null;
     }
 
-    public void invoke(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, int lastChangeTickCount) {
+    public void invoke(EntityInstance firstEntityInstance, Grid grid, int lastChangeTickCount) {
+        EntityInstance newInstance = newEntity.createNewEntityInstance();
+
         if(replaceType == ReplaceActionType.DERIVED) {
-            secondEntityInstance.updateDerivedEntityInstance(firstEntityInstance, lastChangeTickCount);
+            newInstance.updateDerivedEntityInstance(firstEntityInstance, lastChangeTickCount);
         }
 
+        grid.setInstanceInGrid(firstEntityInstance.row, firstEntityInstance.column, newInstance);
         firstEntityInstance.kill();
     }
 }

--- a/Engine/src/simulation/properties/action/impl/replace/ReplaceAction.java
+++ b/Engine/src/simulation/properties/action/impl/replace/ReplaceAction.java
@@ -42,4 +42,13 @@ public class ReplaceAction extends AbstractAction {
         grid.setInstanceInGrid(firstEntityInstance.row, firstEntityInstance.column, newInstance);
         firstEntityInstance.kill();
     }
+
+    public void invokeWithSecondary(EntityInstance firstEntityInstance, EntityInstance secondEntityInstance, Grid grid, int lastChangeTickCount) {
+        if(getContextEntity().equals(firstEntityInstance.getInstanceEntityName())) {
+            invoke(firstEntityInstance, grid, lastChangeTickCount);
+        }
+        else {
+            invoke(secondEntityInstance, grid, lastChangeTickCount);
+        }
+    }
 }

--- a/Engine/src/simulation/properties/rule/Rule.java
+++ b/Engine/src/simulation/properties/rule/Rule.java
@@ -68,36 +68,6 @@ public class Rule implements Serializable {
         return toCompare.name.equals(this.name) && toCompare.activation.equals(this.activation) && toCompare.actions.equals(actions);
     }
 
-    /**
-     * Invokes this rule on all world entities.
-     * Checks if the required amount of ticks has passed.
-     * Will then try to invoke all of this rule's actions on each entity.
-     *
-     * @param entities The world's entities that we invoke the rule on
-     */
-    public void invokeRuleOnWorldEntities(Collection<Entity> entities, int lastChangTickCount) {
-        if (willInvokeByTicks()) {
-            for (Entity e: entities
-                 ) {
-                invokeActionsOnEntity(e, lastChangTickCount);
-            }
-        }
-    }
-
-    /**
-     * Iterates through all actions in the list, if the given entity is an entity that the action
-     * is designed for then invoke said action on all instances of this entity.
-     * @param entity the given entity to invoke the actions upon.
-     */
-    private void invokeActionsOnEntity(Entity entity, int lastChangTickCount){
-        for (Action a: actions
-        ) {
-            if(a.getClass() == MultipleCondition.class || a.getContextEntity().equals(entity.getName()))
-            {
-                entity.invokeActionsOnAllInstances(a, activation.getProbability(), lastChangTickCount);
-            }
-        }
-    }
 
     public List<Action> getActionsToInvoke() {
         List<Action> actionsToInvoke = new ArrayList<>();


### PR DESCRIPTION
- Adjust the simulation runtime to Aviad's model.
- Implement 'invokeWithSecondary' method for each action.
- 'Calculation' & 'Condition' are no longer inherit from 'OneEntAction'.
- Minor changes in 'Proximity' & 'Replace' invoke methods.