### PR TITLE
Minor fixes

### DIFF
--- a/DTO/src/engine2ui/simulation/runtime/ResultData.java
+++ b/DTO/src/engine2ui/simulation/runtime/ResultData.java
@@ -37,11 +37,13 @@ public class ResultData implements Serializable {
     }
 
     /**
-     * Each index in the list represents the tick, the content within each index is the total living population at that tick.
-     * This function adds the population to the list creating another tick documentation.
+     * Each index in the list represents the population after a 20 tick interval
+     * This function adds the population to the list creating another population record for this tick.
      */
-    public void setNextTickPopulation(int population){
-        populationChartData.add(population);
+    public void setPopulationRecord(int population, int currentTick){
+        if(currentTick % 20 == 0){
+            populationChartData.add(population);
+        }
     }
 
     public List<Integer> getPopulationChartData(){

--- a/Engine/src/manager/SimulationManager.java
+++ b/Engine/src/manager/SimulationManager.java
@@ -117,10 +117,11 @@ public class SimulationManager implements EngineInterface, Serializable {
     public StartResponse startSimulation() {
         if(simulationDefinition.isStartable()) {
             DTOCreator dtoCreator = new DTOCreator();
-            SimulationRunData simulationRunData = new SimulationRunData(IdGenerator.generateID(),0, 0, dtoCreator.getDTOEntityList(simulationDefinition.getEntities()), SimulationStatus.WAITING.name(), false);
+            String id = IdGenerator.generateID();
+            SimulationRunData simulationRunData = new SimulationRunData(id,0, 0, dtoCreator.getDTOEntityList(simulationDefinition.getEntities()), SimulationStatus.WAITING.name(), false);
 
             addSimulationToQueue(simulationRunData);
-            return new StartResponse(true, "Simulation was added to the queue successfully.", simulationRunData);
+            return new StartResponse(true, String.format("Simulation %s was added to the queue successfully.", id), simulationRunData);
         } else {
             return new StartResponse(false, "ERROR: Could not start simulation. You need to have at least one entity with a population larger than 0.");
         }

--- a/Engine/src/manager/execution/ExecutionManager.java
+++ b/Engine/src/manager/execution/ExecutionManager.java
@@ -40,7 +40,7 @@ public class ExecutionManager {
     /**
      * Return a new SimulationDataObject when the simulation is ongoing, otherwise return the SimulationRunData from the map.
      */
-    public SimulationRunData getRunDataById(String simId) {
+    public synchronized SimulationRunData getRunDataById(String simId) {
         SimulationInstance simulationInstance = simulations.get(simId);
         DTOCreator dtoCreator = new DTOCreator();
         SimulationRunData ret = null;

--- a/Engine/src/simulation/objects/world/SimulationInstance.java
+++ b/Engine/src/simulation/objects/world/SimulationInstance.java
@@ -235,7 +235,7 @@ public class SimulationInstance implements Serializable, Runnable {
                 invokeActionsOnAllInstances(entity.getEntityInstances(), actionsToInvoke);
             }
 
-            resultData.setNextTickPopulation(calculateRemainingInstances());
+            resultData.setPopulationRecord(calculateRemainingInstances(), ticksCounter.getTicks());
             updateTickAndTime();
         } while ((!endingConditionsMet()));
 

--- a/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
+++ b/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
@@ -131,6 +131,7 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
 
     @Override
     public void onFileLoaded(PreviewData previewData) {
+        populationTF.clear();
         clearListView();
         enableComponent();
         addItemsToListView(previewData.getEntities());

--- a/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
+++ b/UI/src/gui/execution/inputs/entity/EntityPopulationComponentController.java
@@ -40,6 +40,8 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
     private Label entityLabel;
     private int entitiesLeftToAdd;
 
+    private int gridSize;
+
     private Map<DTOEntity, Integer> entityPopulations; // Used for updating the TF values.
 
     public void setMainController(InputsController mainController) {
@@ -142,7 +144,8 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
     }
 
     private int calcGridCells(DTOGridAndThread grid){
-        return grid.getGridRows() * grid.getGridColumns();
+        gridSize = grid.getGridRows() * grid.getGridColumns();
+        return gridSize;
     }
 
     /**
@@ -152,6 +155,7 @@ public class EntityPopulationComponentController implements FileLoadedEvent, Bar
      * @param entities
      */
     private void initEntityPopulations(List<DTOEntity> entities) {
+        updateEntitiesLeft(gridSize);
         for (DTOEntity e : entities
         ) {
             getEngineAgent().sendPopulationData(new EntityPopulationUserInput(e.getName(), 0));

--- a/UI/src/gui/execution/inputs/env/var/EnvironmentVariableComponentController.java
+++ b/UI/src/gui/execution/inputs/env/var/EnvironmentVariableComponentController.java
@@ -129,6 +129,7 @@ public class EnvironmentVariableComponentController implements FileLoadedEvent, 
 
     @Override
     public void onFileLoaded(PreviewData previewData) {
+        valueTF.clear();
         clearListView();
         enableComponent();
         addItemsToListView(previewData.getEnvVariables());

--- a/UI/src/gui/result/details/ExecutionDetailsComponentController.java
+++ b/UI/src/gui/result/details/ExecutionDetailsComponentController.java
@@ -76,12 +76,12 @@ public class ExecutionDetailsComponentController {
         // Binds the enabling and disabling of the control bar to this property
         statusProperty.addListener(((observable, oldValue, newValue) -> {
             switch (SimulationStatus.valueOf(newValue.toString().toUpperCase())) {
-                case WAITING:
                 case COMPLETED:
-                    controlBarAnchorPane.disableProperty().set(false);
-                    break;
-                case ONGOING:
                     controlBarAnchorPane.disableProperty().set(true);
+                    break;
+                case WAITING:
+                case ONGOING:
+                    controlBarAnchorPane.disableProperty().set(false);
                     break;
             }
         }));

--- a/UI/src/gui/result/queue/ExecutionQueueComponentController.java
+++ b/UI/src/gui/result/queue/ExecutionQueueComponentController.java
@@ -14,6 +14,10 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.MouseEvent;
 import manager.EngineAgent;
+import simulation.objects.world.status.SimulationStatus;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ExecutionQueueComponentController implements EngineCommunicator {
     private ResultComponentController mainController;
@@ -28,26 +32,30 @@ public class ExecutionQueueComponentController implements EngineCommunicator {
     @FXML
     private TableColumn<StatusData, String> simStatusCol;
 
+    private Map<StatusData, SimulationStatus> simulationStatusMap;
+
+    private boolean isFetchStatusTaskRunning;
+
     @FXML
     public void initialize() {
         simIdCol.setCellValueFactory(new PropertyValueFactory<>("simId"));
         simStatusCol.setCellValueFactory(new PropertyValueFactory<>("status"));
+        simulationStatusMap = new HashMap<>();
+        isFetchStatusTaskRunning = false;
     }
 
     /**
      * If the selected simulation in the TableView is ongoing or waiting then will create a task that updates the chosen simulation every 200ms.
      * Else will just display the selected simulation.
-     *
      */
     @FXML
     void onMouseClickedTV(MouseEvent event) {
         SimulationRunData selected = mainController.getCurrentSelectedSimulation();
         if (selected != null) {
-            if(selected.isCompleted()){
+            if (selected.isCompleted()) {
                 mainController.updateGuiToChosenSimulation(selected);
-            }
-            else{
-                executeFetchingTask(selected.getSimId());
+            } else {
+                executeSimDataFetchingTask(selected.getSimId());
             }
         }
     }
@@ -57,7 +65,8 @@ public class ExecutionQueueComponentController implements EngineCommunicator {
      * and is ongoing.
      * Every 200ms the task will query the engine for the run data, and will update the SimulationRunDataMap in the parent accordingly.
      */
-    public void executeFetchingTask(String simId){
+    public void executeSimDataFetchingTask(String simId) {
+
         Task<Void> task = new Task<Void>() {
             @Override
             protected Void call() throws Exception {
@@ -77,26 +86,76 @@ public class ExecutionQueueComponentController implements EngineCommunicator {
             }
         };
 
-        Thread thread = new Thread(task);
-        thread.setDaemon(true); // Mark the thread as a daemon to allow application exit
-        thread.start();
+        runTask(task);
     }
 
     public void setMainController(ResultComponentController mainController) {
         this.mainController = mainController;
     }
 
-    public void addSimulationToQueue(SimulationRunData simulationRunData){
-        executionsQueueTV.getItems().add(new StatusData(simulationRunData.getSimId(), new SimpleStringProperty(simulationRunData.getStatus())));
-        executionsQueueTV.refresh();
+    public void addSimulationToQueue(SimulationRunData simulationRunData) {
+        StatusData toAdd = new StatusData(simulationRunData.getSimId(), new SimpleStringProperty(simulationRunData.getStatus()));
+        simulationStatusMap.put(toAdd, SimulationStatus.valueOf(toAdd.getStatus()));
+        executionsQueueTV.getItems().add(toAdd);
+        executeSimStatusFetchingTask();
     }
 
-    public StatusData getQueueSelectedItem(){
+    /**
+     * The task responsible for updating the status in the simulation execution queue.
+     */
+    private void executeSimStatusFetchingTask() {
+        // Check that we don't have more than one instance of this task running.
+        if (!isFetchStatusTaskRunning) {
+            isFetchStatusTaskRunning = true;
+            Task<Void> task = new Task<Void>() {
+                @Override
+                protected Void call() throws Exception {
+                    do {
+                        getStatusUpdatesForRunningSimulations();
+                        Thread.sleep(200); // Make the thread sleep for 200ms
+                    } while (hasNonCompletedSimulations());
+                    return null;
+                }
+            };
+
+            runTask(task);
+        }
+    }
+
+    /**
+     * Iterates on all waiting\ongoing simulations and queries the engine for updates.
+     */
+    private void getStatusUpdatesForRunningSimulations() {
+        for (StatusData s : simulationStatusMap.keySet()
+        ) {
+            if (!s.getStatus().equals(SimulationStatus.COMPLETED.name())) {
+                SimulationRunData selectedInThread = getEngineAgent().getRunDataById(s.getSimId());
+                Platform.runLater(() -> {
+                    s.statusProperty().set(selectedInThread.getStatus());
+                });
+            }
+        }
+    }
+
+    /**
+     * Given a task, this creates a thread for it and runs it.
+     */
+    private void runTask(Task<Void> task){
+        Thread thread = new Thread(task);
+        thread.setDaemon(true); // Mark the thread as a daemon to allow application exit
+        thread.start();
+    }
+
+    private boolean hasNonCompletedSimulations() {
+        return simulationStatusMap.containsValue(SimulationStatus.ONGOING) || simulationStatusMap.containsValue(SimulationStatus.WAITING);
+    }
+
+    public StatusData getQueueSelectedItem() {
         return executionsQueueTV.getSelectionModel().getSelectedItem();
     }
 
     @Override
-    public EngineAgent getEngineAgent() {
+    public synchronized EngineAgent getEngineAgent() {
         return mainController.getEngineAgent();
     }
 }

--- a/UI/src/gui/result/tab/chart/ChartComponent.fxml
+++ b/UI/src/gui/result/tab/chart/ChartComponent.fxml
@@ -6,7 +6,7 @@
 
 <LineChart fx:id="chart" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gui.result.tab.chart.ChartComponentController">
   <xAxis>
-    <CategoryAxis fx:id="ticksAxis" side="BOTTOM" />
+    <NumberAxis fx:id="ticksAxis" side="BOTTOM" />
   </xAxis>
   <yAxis>
     <NumberAxis fx:id="entityQuantityAxis" side="LEFT" />

--- a/UI/src/gui/result/tab/chart/ChartComponentController.java
+++ b/UI/src/gui/result/tab/chart/ChartComponentController.java
@@ -16,7 +16,7 @@ public class ChartComponentController {
     private LineChart<Integer, Integer> chart;  // Specify the types for LineChart
 
     @FXML
-    private CategoryAxis ticksAxis;
+    private NumberAxis ticksAxis;
 
     @FXML
     private NumberAxis entityQuantityAxis;
@@ -30,12 +30,19 @@ public class ChartComponentController {
      * represents the population at that tick.
      */
     public void showPopulationData(List<Integer> population) {
+        chart.getData().clear();
         int tick = 1;
-        XYChart.Series<Integer, Integer> series = new XYChart.Series<>();  // Specify the types for XYChart.Series
+        XYChart.Series<Integer, Integer> series = new XYChart.Series<>();
+
+        // Clear existing data in the series
+        series.getData().clear();
+
         for (Integer i : population) {
-            series.getData().add(new XYChart.Data<>(tick++, i));  // Use 'i' instead of 'population'
+            series.getData().add(new XYChart.Data<>(tick++, i));
         }
-        chart.getData().setAll(series);  // Use setAll to clear and set the data
+
+        // Set the series as the chart's data
+        chart.getData().setAll(series);
     }
 
     public void clearChart(){

--- a/UI/src/gui/result/tab/chart/ChartComponentController.java
+++ b/UI/src/gui/result/tab/chart/ChartComponentController.java
@@ -26,19 +26,20 @@ public class ChartComponentController {
     }
 
     /**
-     * Builds a graph based on the given population list. Each index in the list represents the tick and to content
-     * represents the population at that tick.
+     * Builds a graph based on the given population list. Each index in the list represents
+     * the population in intervals of 20 ticks.
      */
     public void showPopulationData(List<Integer> population) {
         chart.getData().clear();
-        int tick = 1;
+        int tick = 0;
         XYChart.Series<Integer, Integer> series = new XYChart.Series<>();
 
         // Clear existing data in the series
         series.getData().clear();
 
         for (Integer i : population) {
-            series.getData().add(new XYChart.Data<>(tick++, i));
+            series.getData().add(new XYChart.Data<>(tick, i));
+            tick += 20;
         }
 
         // Set the series as the chart's data

--- a/UI/src/gui/sub/menus/SubMenusController.java
+++ b/UI/src/gui/sub/menus/SubMenusController.java
@@ -62,7 +62,6 @@ public class SubMenusController implements HasFileLoadedListeners, BarNotifier, 
     public BarNotifier getNotificationBar() {
         return mainController.getNotificationBar();
     }
-
     @Override
     public EngineAgent getEngineAgent() {
         return mainController.getEngineAgent();

--- a/UI/src/manager/EngineAgent.java
+++ b/UI/src/manager/EngineAgent.java
@@ -398,7 +398,7 @@ public class EngineAgent {
         return engine.startSimulation();
     }
 
-    public SimulationRunData getRunDataById(String simId) {
+    public synchronized SimulationRunData getRunDataById(String simId) {
         return engine.getRunDataById(simId);
     }
 


### PR DESCRIPTION
- The task responsible for updating statuses in the execution queue now works properly.
- The graph doesn't crash the program anymore after a large amount of ticks (This was tested up to 50,000 ticks).
- When a new simulation is loaded the previous data in the input text fields in the simulation screens is now cleared.
- When using the clear button the 'entities to add' counter is now also reset.
- There are now notifications for wen simulation runs are added to queue, starting their run and completing their run.